### PR TITLE
Add DuckDuckGo Support

### DIFF
--- a/lib/services/duckduckgo.ex
+++ b/lib/services/duckduckgo.ex
@@ -1,0 +1,22 @@
+defmodule Omnixent.Services.DuckDuckGo do
+  @duckduckgo_endpoint "https://duckduckgo.com/ac/?q="
+  @duckduckgo_queryparams "&client=psy-ab&"
+
+  @spec format_uri(string, atom, atom) :: string
+  def format_uri(term, country, language) do
+    @duckduckgo_endpoint <>
+      URI.encode(term) <>
+      @duckduckgo_queryparams <>
+      "kl=" <>
+      String.downcase(Atom.to_string(country)) <>
+      "-" <>
+      String.downcase(Atom.to_string(language))
+  end
+
+  @spec extract_body(binary) :: list(string)
+  def extract_body(response) do
+    "#{:erlang.binary_to_list(response)}"
+    |> Omnixent.Utils.safe_json_decode()
+    |> Enum.map(fn a -> a["phrase"] end)
+  end
+end

--- a/lib/services/search.ex
+++ b/lib/services/search.ex
@@ -74,6 +74,8 @@ defmodule Omnixent.Services do
         Omnixent.Services.Youtube.format_uri(term, country, language)
       :amazon ->
         Omnixent.Services.Amazon.format_uri(term, country, language)
+      :duckduckgo ->
+        Omnixent.Services.DuckDuckGo.format_uri(term, country, language)
     end
   end
 
@@ -85,6 +87,8 @@ defmodule Omnixent.Services do
         Omnixent.Services.Youtube.extract_body(body)
       :amazon ->
         Omnixent.Services.Amazon.extract_body(body)
+      :duckduckgo ->
+        Omnixent.Services.DuckDuckGo.extract_body(body)
     end
   end
 

--- a/test/services_test.exs
+++ b/test/services_test.exs
@@ -2,6 +2,7 @@ defmodule Omnixent.Services.Test do
   use ExUnit.Case
   alias Omnixent.Services.Google
   alias Omnixent.Services.Youtube
+  alias Omnixent.Services.DuckDuckGo
   doctest Omnixent.Services
 
   test "Google.format_uri should correctly format a valid Google URI" do
@@ -11,5 +12,8 @@ defmodule Omnixent.Services.Test do
   test "Youtube.format_uri should correctly format a valid Youtube URI" do
     Youtube.format_uri("java", :us, :en) == "https://clients1.google.com/complete/search?q=java&client=youtube&gs_ri=youtubehl=en&gl=US"
   end
-
+  
+  test "DuckDuckGo.format_uri should correctly format a valid DuckDuckGo URI" do
+    DuckDuckGo.format_uri("java", :us, :en) == "https://duckduckgo.com/ac/?q=java&client=psy-ab&kl=en-us"
+  end
 end


### PR DESCRIPTION
Close #12 

I've been able to test the functions isolated, like this: `Omnixent.Services.call_service("Jav", :en, :us, :duckduckgo)`

But I can't make the `Omnixent.Services.search("java", :duckduckgo, :us, :en)` work on my computer. I keep getting the following error:

```
** (Memento.Error) Transaction Failed with: {:no_exists, Omnixent.Mnesia}
    (memento 0.3.1) lib/memento/transaction.ex:178: Memento.Transaction.handle_result/1
    (omnixent 0.0.6) lib/services/search.ex:32: Omnixent.Services.search/4
```