### PR TITLE
Add bing support

### DIFF
--- a/src/lib/services/bing.ts
+++ b/src/lib/services/bing.ts
@@ -1,0 +1,15 @@
+import { ServiceArgs } from "./index.ts";
+import { normalizeServiceArgs } from "../utils/index.ts";
+
+const endpoint = "https://api.bing.com/osjson.aspx";
+
+export function formatURI(options: ServiceArgs): string {
+  const { t, hl } = normalizeServiceArgs(options);
+  return `${endpoint}?query=${t}&cc=${hl}`;
+}
+
+export function extractBody(response: string) {
+  return JSON
+    .parse(response)[1]
+    ?.map((phrase: string) => phrase);
+}

--- a/src/lib/services/bing.ts
+++ b/src/lib/services/bing.ts
@@ -4,8 +4,8 @@ import { normalizeServiceArgs } from "../utils/index.ts";
 const endpoint = "https://api.bing.com/osjson.aspx";
 
 export function formatURI(options: ServiceArgs): string {
-  const { t, hl } = normalizeServiceArgs(options);
-  return `${endpoint}?query=${t}&cc=${hl}`;
+  const { t, c, l } = normalizeServiceArgs(options);
+  return `${endpoint}?query=${t}&mkt=${l}-${c}`;
 }
 
 export function extractBody(response: string) {


### PR DESCRIPTION
Closes #11 
- added bing support

Hi there,
I added the bing support we should understand their API a bit in order to make the perfect implementation.

I share here the [Market codes](https://docs.microsoft.com/en-us/bing/search-apis/bing-web-search/reference/market-codes) and [Query Parameters](https://docs.microsoft.com/en-us/bing/search-apis/bing-web-search/reference/query-parameters#cc) of the bing search engine API.

Now I've implemented the `mkt` parameters because it seems to be more efficient and getting back some good results.
As you can see the mkt parameters is not in the [RFC5646 standard](https://tools.ietf.org/html/rfc5646): I'm concatenating the language and country code variables on the fly into the `bing.ts file`.